### PR TITLE
Remove irrelevant vals from MvpVmViewModel

### DIFF
--- a/app/src/main/java/beepbeep/learning_mvvm/mvpvm/MvpVmPresenter.kt
+++ b/app/src/main/java/beepbeep/learning_mvvm/mvpvm/MvpVmPresenter.kt
@@ -4,18 +4,15 @@ import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
 import io.reactivex.subjects.BehaviorSubject
 
-class MvpVmPresenter(val input: MvpVmContract.Input) : MvpVmContract.Output {
+class MvpVmPresenter(input: MvpVmContract.Input) : MvpVmContract.Output {
 
-    override val outputViewModel: BehaviorSubject<MvpVmViewModel> = BehaviorSubject.createDefault<MvpVmViewModel>(MvpVmViewModel("", "", ""))
-
-//    override val outputViewModel: Observable<MvpVmViewModel> =
-//            input.buttonEvent.map { publisher.value }
+    override val outputViewModel: BehaviorSubject<MvpVmViewModel> = BehaviorSubject.createDefault<MvpVmViewModel>(MvpVmViewModel(""))
 
     init {
         Observable.combineLatest(input.name, input.favoriteAnimal,
                 BiFunction<String, String, MvpVmViewModel> {
                     name:String, favoriteAnimal:String ->
-                    MvpVmViewModel(name, favoriteAnimal, name + " likes " + favoriteAnimal)
+                    MvpVmViewModel(name + " likes " + favoriteAnimal)
                 }
         ).subscribe(outputViewModel)
     }

--- a/app/src/main/java/beepbeep/learning_mvvm/mvpvm/MvpVmViewModel.kt
+++ b/app/src/main/java/beepbeep/learning_mvvm/mvpvm/MvpVmViewModel.kt
@@ -1,3 +1,3 @@
 package beepbeep.learning_mvvm.mvpvm
 
-class MvpVmViewModel(val name: String, val favoriteAnimal: String, val displayString: String)
+data class MvpVmViewModel(val displayString: String)

--- a/app/src/test/java/beepbeep/learning_mvvm/mvpvm/MvpVmPresenterTest.kt
+++ b/app/src/test/java/beepbeep/learning_mvvm/mvpvm/MvpVmPresenterTest.kt
@@ -31,17 +31,17 @@ class MvpVmPresenterTest {
         favoriteAnimalSubject.onNext("cat")
 
         testObserver.assertValueAt(1) {
-            it.displayString.equals("JR likes cat")
+            it.displayString == "JR likes cat"
         }
 
         nameSubject.onNext("Mr. Yama")
         testObserver.assertValueAt(2) {
-            it.displayString.equals("Mr. Yama likes cat")
+            it.displayString == "Mr. Yama likes cat"
         }
 
         favoriteAnimalSubject.onNext("corgi")
         testObserver.assertValueAt(3) {
-            it.displayString.equals("Mr. Yama likes corgi")
+            it.displayString == "Mr. Yama likes corgi"
         }
     }
 }


### PR DESCRIPTION
I removed `name` and `favoriteAnimal` properties from `MvpVmViewModel` because in my opinion there just adding noise to the view model.